### PR TITLE
enable an :allow_nil option for affirmations

### DIFF
--- a/lib/daily_affirmation.rb
+++ b/lib/daily_affirmation.rb
@@ -1,3 +1,4 @@
+require_relative "daily_affirmation/process_affirmation_evaluator"
 require_relative "daily_affirmation/affirmations"
 require_relative "daily_affirmation/validators/absence_validator"
 require_relative "daily_affirmation/validators/acceptance_validator"

--- a/lib/daily_affirmation/affirmations.rb
+++ b/lib/daily_affirmation/affirmations.rb
@@ -37,13 +37,7 @@ module DailyAffirmation
       attribute = affirmation[:attribute]
       args = affirmation.reject { |k, _| [:type, :attribute].include?(k) }
 
-      process_validation = if args.include?(:if)
-                             instance_eval(&args[:if])
-                           else
-                             true
-                           end
-
-      if process_validation
+      if ProcessAffirmationEvaluator.new(object, attribute, args).process?
         validator = Object.const_get(
           "DailyAffirmation::Validators::#{type.to_s.capitalize}Validator"
         )

--- a/lib/daily_affirmation/process_affirmation_evaluator.rb
+++ b/lib/daily_affirmation/process_affirmation_evaluator.rb
@@ -1,0 +1,31 @@
+class ProcessAffirmationEvaluator
+  def initialize(object, attribute, args)
+    self.object = object
+    self.attribute = attribute
+    self.args = args
+  end
+
+  def process?
+    if_statement_passes? && allow_nil_passes?
+  end
+
+  private
+
+  attr_accessor :object, :attribute, :args
+
+  def if_statement_passes?
+    if args.include?(:if)
+      instance_eval(&args[:if])
+    else
+      true
+    end
+  end
+
+  def allow_nil_passes?
+    if args.include?(:allow_nil)
+      object.send(attribute)
+    else
+      true
+    end
+  end
+end

--- a/spec/daily_affirmation_spec.rb
+++ b/spec/daily_affirmation_spec.rb
@@ -135,6 +135,23 @@ describe DailyAffirmation do
     expect(affirmation2).to_not be_valid
   end
 
+  it "skips an affirmation for an :allow_nil option" do
+    cls = Class.new do
+      include DailyAffirmation.affirmations
+
+      affirms_format_of :name, :regex => /^\D+$/, :allow_nil => true
+    end
+
+    obj1 = double(:name => nil)
+    obj2 = double(:name => "name1")
+
+    affirmation1 = cls.new(obj1)
+    affirmation2 = cls.new(obj2)
+
+    expect(affirmation1).to be_valid
+    expect(affirmation2).to_not be_valid
+  end
+
   it "allows each affirmation to be inverted via an :inverse option" do
     cls = Class.new do
       include DailyAffirmation.affirmations

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require "coveralls"
+require "pry"
+
 Coveralls.wear!
 
 RSpec.configure do |config|


### PR DESCRIPTION
- moves logic to check for passing arguments
