### PR TITLE
add before and after options to date validator

### DIFF
--- a/lib/daily_affirmation/validators/date_validator.rb
+++ b/lib/daily_affirmation/validators/date_validator.rb
@@ -4,7 +4,7 @@ module DailyAffirmation
   module Validators
     class DateValidator < Validator
       def valid?
-        @valid ||= parseable?
+        @valid ||= parseable? && before? && after?
       end
 
       def error_message
@@ -23,6 +23,22 @@ module DailyAffirmation
 
       def as
         opts.fetch(:as, :date)
+      end
+
+      def before?
+        if opts[:before]
+          value < opts[:before]
+        else
+          true
+        end
+      end
+
+      def after?
+        if opts[:after]
+          value > opts[:after]
+        else
+          true
+        end
       end
 
       def klass

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -132,4 +132,32 @@ describe "DateValidator" do
       }.to raise_error(DailyAffirmation::OptionError)
     end
   end
+
+  context "the :before option is passed" do
+    it "passes validation if the date is before the date passed in :before" do
+      obj = double(:created_at => Date.today.prev_year(2))
+      validator = subject.new(obj, :created_at, :before => Date.today.prev_year)
+      expect(validator).to be_valid
+    end
+
+    it "fails validation if the date is after the date passed in :before" do
+      obj = double(:created_at => Date.today)
+      validator = subject.new(obj, :created_at, :before => Date.today.prev_year)
+      expect(validator).to_not be_valid
+    end
+  end
+
+  context "the :after option is passed" do
+    it "fails validation if the date is before the date passed in :after" do
+      obj = double(:created_at => Date.today.prev_year(2))
+      validator = subject.new(obj, :created_at, :after => Date.today.prev_year)
+      expect(validator).to_not be_valid
+    end
+
+    it "passes validation if the date is after the date passed in :after" do
+      obj = double(:created_at => Date.today)
+      validator = subject.new(obj, :created_at, :after => Date.today.prev_year)
+      expect(validator).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
I noticed that the numericality validator had `:greater_than` and `:less_than`. I went with `:before` and `:after` as I felt it was more accurate in relation to a date.
