### PR TITLE
allow callable objects to be passed into before/after options

### DIFF
--- a/lib/daily_affirmation/validators/date_validator.rb
+++ b/lib/daily_affirmation/validators/date_validator.rb
@@ -3,6 +3,11 @@ require_relative "../validator"
 module DailyAffirmation
   module Validators
     class DateValidator < Validator
+      class NullDateLike
+        def <(val); true; end
+        def >(val); true; end
+      end
+
       def valid?
         @valid ||= parseable? && before? && after?
       end
@@ -25,20 +30,26 @@ module DailyAffirmation
         opts.fetch(:as, :date)
       end
 
+      def before
+        @before ||= -> {
+          val = opts.fetch(:before, NullDateLike.new)
+          val.respond_to?(:call) ? val.call : val
+        }.call
+      end
+
       def before?
-        if opts[:before]
-          value < opts[:before]
-        else
-          true
-        end
+        before > value
+      end
+
+      def after
+        @after ||= -> {
+          val = opts.fetch(:after, NullDateLike.new)
+          val.respond_to?(:call) ? val.call : val
+        }.call
       end
 
       def after?
-        if opts[:after]
-          value > opts[:after]
-        else
-          true
-        end
+        after < value
       end
 
       def klass

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -145,6 +145,14 @@ describe "DateValidator" do
       validator = subject.new(obj, :created_at, :before => Date.today.prev_year)
       expect(validator).to_not be_valid
     end
+
+    it "allows a proc to be passed into before" do
+      obj = double(:created_at => Date.today.prev_year(2))
+      validator = subject.new(
+        obj, :created_at, :before => ->{ Date.today.prev_year }
+      )
+      expect(validator).to be_valid
+    end
   end
 
   context "the :after option is passed" do
@@ -157,6 +165,14 @@ describe "DateValidator" do
     it "passes validation if the date is after the date passed in :after" do
       obj = double(:created_at => Date.today)
       validator = subject.new(obj, :created_at, :after => Date.today.prev_year)
+      expect(validator).to be_valid
+    end
+
+    it "allows a proc to be passed into after" do
+      obj = double(:created_at => Date.today)
+      validator = subject.new(
+        obj, :created_at, :after => ->{ Date.today.prev_year }
+      )
       expect(validator).to be_valid
     end
   end


### PR DESCRIPTION
since dates passed at the class level would not be evaluated at run time, if you are referencing `Date.today` or `DateTime.now` those would not be evaluated properly. This will accept a callable value for the `:before` and `:after` options.
